### PR TITLE
Fixing cryptography dependency pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "dbt-core~={}".format(dbt_core_version),
         "snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.0",
         "requests<3.0.0",
-        "cryptography>=3.2,<4",
+        "cryptography>=3.2,<37.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
For some reason the folks at cryptography decided to flip the table
on their versioning schema and went from 3.4.8 to 35.0.

This is now causing build failures for the dbt-snowflake package, as
it's pinning the max version to be `<4`, while other dependencies of
this package don't have such restriction, causing a conflict within
available and required versions.

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.
